### PR TITLE
fix: re-add `PFin2.elim0`

### DIFF
--- a/Qpf/MathlibPort/Fin2.lean
+++ b/Qpf/MathlibPort/Fin2.lean
@@ -46,6 +46,10 @@ inductive PFin2 : Nat → Type u
 
 namespace PFin2
 
+/-- Ex falso. The dependent eliminator for the empty `PFin2 0` type. -/
+def elim0 {C : PFin2 0 → Sort u} : ∀ i : PFin2 0, C i :=
+  by intro i; cases i
+
 /-- Converts a `PFin2` into a natural. -/
 def toNat : ∀ {n}, PFin2 n → Nat
   | _, @fz _ => 0


### PR DESCRIPTION
Removing `PFin2.elim0` in https://github.com/alexkeizer/QpfTypes/commit/7e5089741403ff07782fc81a339d24cb1513ed43 broke the `Test` build for me. Maybe there is a better fix than just readding it but this seemed easiest for me now :)