### PR TITLE
refactor: `is_trivial` check to be more succinct 

### DIFF
--- a/Qpf/Macro/Comp.lean
+++ b/Qpf/Macro/Comp.lean
@@ -194,14 +194,7 @@ partial def handleApp (vars : Vector FVarId arity) (target : Q(Type u))  : TermE
     In such cases, we can directly return `G`, rather than generate a composition of projections.
   -/
 
-  -- O(n²), equivalent to a zipping and would be O(n) and much more readable
-  let is_trivial :=
-    args.length == arity
-    && args.toList.enum.all fun ⟨i, arg⟩ =>
-        arg.isFVar && isLiveVar vars arg.fvarId! && vars'.indexOf arg.fvarId! == i
-  -- Equivalent (?), O(n), and more readable
-  -- TODO: is this really equivalent
-  /- let is_trivial := (args.toList.mapM Expr.fvarId?).any (· == vars') -/
+  let is_trivial := args.toList.mapM Expr.fvarId? == some vars'
 
   if is_trivial then
     trace[QPF] "The application is trivial"


### PR DESCRIPTION
If we start with
```lean
let is_trivial :=
  args.length == arity
  && args.toList.enum.all fun ⟨i, arg⟩ =>
      arg.isFVar && isLiveVar vars arg.fvarId! && vars'.indexOf arg.fvarId! == i
```

Then we can first observe that
`vars'.indexOf arg.fvarId! == i => isLiveVar vars arg.fvarId!`.
this comes from indexOf returning the length of the array if the entry is not found.
Since 0 ≤ i < vars'.legnth we can never have i == vars'.length thereby the impl holds
so we can remove the isLive check

```lean
let is_trivial :=
  args.length == arity
  && args.toList.enum.all fun ⟨i, arg⟩ =>
      arg.isFVar && vars'.indexOf arg.fvarId! == i
```

Then we can re-arrange to take the transform for fvarIds out

```lean
let is_trivial :=
  args.length == arity
  && (args.toList.mapM Expr.fvarId?).any
    (·.enum.all fun ⟨i, arg⟩ => vars'.indexOf arg == i)
```

Now observe how we are checking an index at each step along the way.
If the arrays have the same length (the first check) we then know if they are equal this holds.
So by doing the next transform we get:


```lean
let is_trivial :=
  args.length == arity
  && (args.toList.mapM Expr.fvarId?).any (· == vars')
```

And finally if the arrays are equal it implies the first condition so we end up with:

```lean
let is_trivial := (args.toList.mapM Expr.fvarId?).any (· == vars')
```

Which happends to also correspond to what the documentation states

