### PR TITLE
feat: add the ability to access the uncurried base

### DIFF
--- a/Qpf/Macro/Data.lean
+++ b/Qpf/Macro/Data.lean
@@ -412,7 +412,8 @@ def isPolynomial (view : DataView) (F: Term) : CommandElabM (Option Term) := do
 def mkType (view : DataView) (base : Term × Term × Term) : CommandElabM Unit := do
   trace[QPF] "mkType"
   let uncurriedIdent ← addSuffixToDeclIdent view.declId "Uncurried"
-  let baseIdent ← addSuffixToDeclIdent view.declId "Base"
+  let baseIdExt ← addSuffixToDeclIdent view.declId "Base"
+  let baseIdent ← addSuffixToDeclIdent baseIdExt "Uncurried"
   let baseFunctorIdent ← addSuffixToDeclIdent baseIdent "instMvFunctor"
   let baseQPFIdent ← addSuffixToDeclIdent baseIdent "instQPF"
 
@@ -429,6 +430,9 @@ def mkType (view : DataView) (base : Term × Term × Term) : CommandElabM Unit :
   let cmd ← `(
     abbrev $baseIdent:ident $view.deadBinders:bracketedBinder* : TypeFun $(quote <| arity + 1) :=
       $base
+
+    abbrev $baseIdExt $view.deadBinders:bracketedBinder*
+      := TypeFun.curried $baseApplied
 
     instance $baseFunctorIdent:ident : MvFunctor ($baseApplied) := $functor
     instance $baseQPFIdent:ident : MvQPF ($baseApplied) := $q

--- a/Qpf/Macro/Data.lean
+++ b/Qpf/Macro/Data.lean
@@ -431,8 +431,8 @@ def mkType (view : DataView) (base : Term × Term × Term) : CommandElabM Unit :
     abbrev $baseIdent:ident $view.deadBinders:bracketedBinder* : TypeFun $(quote <| arity + 1) :=
       $base
 
-    abbrev $baseIdExt $view.deadBinders:bracketedBinder*
-      := TypeFun.curried $baseApplied
+    abbrev $baseIdExt $view.deadBinders:bracketedBinder* := 
+      TypeFun.curried $baseApplied
 
     instance $baseFunctorIdent:ident : MvFunctor ($baseApplied) := $functor
     instance $baseQPFIdent:ident : MvQPF ($baseApplied) := $q


### PR DESCRIPTION
Currently, we only expose the curried `Base` functor for each given type, this limits how we are able to extend the `Base` functor and would limit adding `DeepThunk`s to the code as these require the uncurried `Base` functor